### PR TITLE
nits: reformat and typo

### DIFF
--- a/src/main/scala/com/softwaremill/tapir/scalaxb/example/Endpoints.scala
+++ b/src/main/scala/com/softwaremill/tapir/scalaxb/example/Endpoints.scala
@@ -18,7 +18,7 @@ object Endpoints {
   // that is needed by scalaxb code to property decode given xml
   case class XmlNamespace(namespace: String)
 
-  implicit val outerSchemaWithXmlNamspace: Schema[Outer] = implicitly[Derived[Schema[Outer]]].value
+  implicit val outerSchemaWithXmlNamespace: Schema[Outer] = implicitly[Derived[Schema[Outer]]].value
     .docsExtension("xml", XmlNamespace("http://www.example.com/innerouter"))
 
   import com.softwaremill.tapir.scalaxb.example.xml._

--- a/src/main/scala/com/softwaremill/tapir/scalaxb/example/Endpoints.scala
+++ b/src/main/scala/com/softwaremill/tapir/scalaxb/example/Endpoints.scala
@@ -17,10 +17,12 @@ object Endpoints {
   // attribute (look at "Prefixes and Namespaces" section at https://swagger.io/docs/specification/data-models/representing-xml/),
   // that is needed by scalaxb code to property decode given xml
   case class XmlNamespace(namespace: String)
+
   implicit val outerSchemaWithXmlNamspace: Schema[Outer] = implicitly[Derived[Schema[Outer]]].value
     .docsExtension("xml", XmlNamespace("http://www.example.com/innerouter"))
 
   import com.softwaremill.tapir.scalaxb.example.xml._
+
   // `label` is needed by scalaxb code to properly encode the top node of the xml
   implicit val label: XmlElementLabel = XmlElementLabel("outer")
 


### PR DESCRIPTION
Changes:
* reformat all `*.scala` files with _scalafmt_
* fix typo in `Endpoints.scala`